### PR TITLE
AAGSB-1174 add ComposableWebVideoServer class definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(async_web_server_cpp REQUIRED)
 find_package(cv_bridge REQUIRED)
 find_package(image_transport REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rclcpp_components REQUIRED)
 find_package(sensor_msgs REQUIRED)
 
 find_package(OpenCV REQUIRED)
@@ -17,7 +18,6 @@ pkg_check_modules(avcodec libavcodec REQUIRED)
 pkg_check_modules(avformat libavformat REQUIRED)
 pkg_check_modules(avutil libavutil REQUIRED)
 pkg_check_modules(swscale libswscale REQUIRED)
-
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
@@ -38,9 +38,10 @@ include_directories(include
   ${avutil_INCLUDE_DIRS}
   ${swscale_INCLUDE_DIRS}
 )
+add_compile_options(-Wno-deprecated-declarations)
 
-## Declare a cpp executable
-add_executable(${PROJECT_NAME}
+## Declare a cpp library
+add_library(${PROJECT_NAME}
   src/web_video_server.cpp
   src/image_streamer.cpp
   src/libav_streamer.cpp
@@ -52,9 +53,10 @@ add_executable(${PROJECT_NAME}
   src/jpeg_streamers.cpp
   src/png_streamers.cpp
 )
+rclcpp_components_register_nodes(${PROJECT_NAME} "${PROJECT_NAME}::ComposableWebVideoServer")
 
 ament_target_dependencies(${PROJECT_NAME}
-  async_web_server_cpp cv_bridge image_transport rclcpp sensor_msgs)
+  async_web_server_cpp cv_bridge image_transport rclcpp rclcpp_components sensor_msgs)
 
 ## Specify libraries to link a library or executable target against
 target_link_libraries(${PROJECT_NAME}
@@ -66,12 +68,26 @@ target_link_libraries(${PROJECT_NAME}
   ${swscale_LIBRARIES}
 )
 
+## Declare a cpp executable
+add_executable(${PROJECT_NAME}_node
+  src/web_video_server_node.cpp
+)
+target_link_libraries(${PROJECT_NAME}_node ${PROJECT_NAME})
+
 #############
 ## Install ##
 #############
 
 ## Mark executables and/or libraries for installation
-install(TARGETS ${PROJECT_NAME}
+install(
+  TARGETS ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(TARGETS ${PROJECT_NAME}_node
   DESTINATION lib/${PROJECT_NAME}
 )
 
@@ -80,4 +96,8 @@ install(DIRECTORY include/${PROJECT_NAME}/
    FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
 )
 
+ament_export_include_directories(include)
+ament_export_libraries(${PROJECT_NAME})
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_dependencies(async_web_server_cpp cv_bridge image_transport rclcpp rclcpp_components sensor_msgs)
 ament_package()

--- a/include/web_video_server/web_video_server.h
+++ b/include/web_video_server/web_video_server.h
@@ -3,6 +3,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <cv_bridge/cv_bridge.h>
+#include <memory>
 #include <vector>
 #include "web_video_server/image_streamer.h"
 #include "async_web_server_cpp/http_server.hpp"
@@ -24,11 +25,14 @@ public:
    * @return
    */
   WebVideoServer(rclcpp::Node::SharedPtr &nh, rclcpp::Node::SharedPtr &private_nh);
-
+  
+  WebVideoServer();
   /**
    * @brief  Destructor - Cleans up
    */
   virtual ~WebVideoServer();
+
+  void initialize(rclcpp::Node::SharedPtr nh, rclcpp::Node::SharedPtr private_nh);
 
   /**
    * @brief  Starts the server and spins
@@ -49,7 +53,7 @@ public:
   bool handle_list_streams(const async_web_server_cpp::HttpRequest &request,
                            async_web_server_cpp::HttpConnectionPtr connection, const char* begin, const char* end);
 
-private:
+protected:
   void restreamFrames(double max_age);
   void cleanup_inactive_streams();
 
@@ -67,6 +71,27 @@ private:
   boost::mutex subscriber_mutex_;
 };
 
-}
+/**
+ * @class ComposableWebVideoServer
+ * @brief
+ */
+class ComposableWebVideoServer :
+    public rclcpp::Node
+  , public WebVideoServer
+{
+public:
+  /**
+   * @brief  Constructor
+   * @return
+   */
+  explicit ComposableWebVideoServer(rclcpp::NodeOptions const & options);
 
+  /**
+   * @brief  Destructor - Cleans up
+   */
+  virtual ~ComposableWebVideoServer();
+
+};
+
+}
 #endif

--- a/include/web_video_server/web_video_server.h
+++ b/include/web_video_server/web_video_server.h
@@ -3,7 +3,6 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <cv_bridge/cv_bridge.h>
-#include <memory>
 #include <vector>
 #include "web_video_server/image_streamer.h"
 #include "async_web_server_cpp/http_server.hpp"

--- a/package.xml
+++ b/package.xml
@@ -21,13 +21,15 @@
   <build_depend>async_web_server_cpp</build_depend>
   <build_depend>ffmpeg</build_depend>
   <build_depend>sensor_msgs</build_depend>
-
+  <build_depend>rclcpp_components</build_depend>
+  
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>cv_bridge</exec_depend>
   <exec_depend>image_transport</exec_depend>
   <exec_depend>async_web_server_cpp</exec_depend>
   <exec_depend>ffmpeg</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>rclcpp_components</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/web_video_server_node.cpp
+++ b/src/web_video_server_node.cpp
@@ -1,0 +1,14 @@
+#include "web_video_server/web_video_server.h"
+
+int main(int argc, char **argv)
+{
+  rclcpp::init(argc, argv);
+  auto nh = std::make_shared<rclcpp::Node>("web_video_server");
+  auto private_nh = std::make_shared<rclcpp::Node>("_web_video_server");
+
+  web_video_server::WebVideoServer server(nh, private_nh);
+  server.setup_cleanup_inactive_streams();
+  server.spin();
+
+  return (0);
+}


### PR DESCRIPTION
*Description*
* refactor `WebVideoServer` class definition to allow for inheritance:
  * added `web_video_server_node` executable
  * added `web_video_server` shared library to export `WebVideoServer` and child `ComposableWebVideoServer`
* Added child class `ComposableWebVideoServer` to allow node composition to limit network utilization for raw ROS image streams

*Testing*
* Verified refactored code did not introduce regressions:  `ros2 run web_video_server web_video_server_node` creates server on localhost port 8080 for serving (compressed) video streams from ros2 topic
* Verified composed node works as expected when combined with `ecam_v4l2` camera node (see [this PR](https://github.com/offworld-projects/swarm-robotic-mining/pull/763)): `ros2 run bot_econ_streamer econ_camera_streamer --ros-args -p cameras:=["See3CAM_CU20_32310E0E"]`