### PR TITLE
AAGSB-1390 setup web video server to only advertise specific streaming topics

### DIFF
--- a/include/web_video_server/web_video_server.h
+++ b/include/web_video_server/web_video_server.h
@@ -60,6 +60,7 @@ protected:
   rclcpp::WallTimer<rclcpp::VoidCallbackType>::SharedPtr cleanup_timer_;
   int ros_threads_;
   double publish_rate_;
+  std::vector<std::string> advertise_topics_;
   int port_;
   std::string address_;
   boost::shared_ptr<async_web_server_cpp::HttpServer> server_;

--- a/include/web_video_server/web_video_server.h
+++ b/include/web_video_server/web_video_server.h
@@ -59,7 +59,7 @@ protected:
   rclcpp::Node::SharedPtr nh_;
   rclcpp::WallTimer<rclcpp::VoidCallbackType>::SharedPtr cleanup_timer_;
   int ros_threads_;
-  double publish_rate_;
+  int publish_rate_;
   std::vector<std::string> advertise_topics_;
   int port_;
   std::string address_;


### PR DESCRIPTION
_Description_

* To better support a single camera stream per port using `web_video_server` node, limit the topics to advertise streams for

_Testing_

* run 3 single camera processes and pass the corresponding topic names as parameter `advertise_topics` to the `web_video_server` and verify that only the advertised topics are listed on the landing page; e.g., 0.0.0.0:8080
* * verified that trying to reach streams not specified at launch gives a `404` error
* * verified that trying to reach a snapshot from a stream not specified at launch also gives a `404` error